### PR TITLE
When confusing the packaged jar package of springboot maven, the BOOT…

### DIFF
--- a/dev.skidfuscator.obfuscator/src/main/java/dev/skidfuscator/obfuscator/phantom/jphantom/PhantomResolvingJarDumper.java
+++ b/dev.skidfuscator.obfuscator/src/main/java/dev/skidfuscator/obfuscator/phantom/jphantom/PhantomResolvingJarDumper.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
+import java.util.zip.CRC32;
 import java.util.zip.ZipException;
 
 /**
@@ -264,6 +265,13 @@ public class PhantomResolvingJarDumper implements JarDumper {
 	@Override
 	public int dumpResource(JarOutputStream out, String name, byte[] file) throws IOException {
 		JarEntry entry = new JarEntry(name);
+		if (name.endsWith(".jar")){
+			entry.setMethod(JarEntry.STORED);
+			entry.setSize(file.length);
+			CRC32 crc = new CRC32();
+			crc.update(file);
+			entry.setCrc(crc.getValue());
+		}
 		out.putNextEntry(entry);
 		out.write(file);
 		return 1;


### PR DESCRIPTION
When confusing the packaged jar package of springboot maven, the BOOT INF/lib/directory will store the jar package we rely on. If ZipEntry. STORED is not set, it will result in an error that the jar package cannot be read. The error is as follows:
Caused by: java. lang. IllegalState Exception: Unable to open nested entry 'BOOT INF/lib/aaaa. jar'. It has been compressed and nested jar files must be stored without compression Please check the mechanism used to create your executable jar file