### PR TITLE
Bring default Transformers back to the community version

### DIFF
--- a/dev.skidfuscator.obfuscator/src/main/java/dev/skidfuscator/obfuscator/Skidfuscator.java
+++ b/dev.skidfuscator.obfuscator/src/main/java/dev/skidfuscator/obfuscator/Skidfuscator.java
@@ -633,7 +633,7 @@ public class Skidfuscator {
     public List<Transformer> getTransformers() {
         final List<Transformer> transformers = new ArrayList<>();
 
-        if (false) {
+        if (true) {
             if (tsConfig.hasPath("stringEncryption.type")) {
                 switch (tsConfig.getEnum(StringEncryptionType.class, "stringEncryption.type")) {
                     case STANDARD: transformers.add(new StringTransformer(this)); break;


### PR DESCRIPTION
After commit <https://github.com/skidfuscatordev/skidfuscator-java-obfuscator/commit/4bb9d944c4b129f55f7f7f5e8d47425426c3f083>, Skidfuscator couldn't intialize any transformers for community version. This PR brings them back.