### PR TITLE
Fixed ahegao failing issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ allprojects {
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     }
+
+    compileJava {
+        options.encoding = "UTF-8" // Will fail on the non-ascii comments if not set
+    }
 }
 
 group 'dev.skidfuscator.community'

--- a/dev.skidfuscator.obfuscator/src/main/java/dev/skidfuscator/obfuscator/transform/impl/misc/AhegaoTransformer.java
+++ b/dev.skidfuscator.obfuscator/src/main/java/dev/skidfuscator/obfuscator/transform/impl/misc/AhegaoTransformer.java
@@ -28,6 +28,9 @@ import java.util.List;
 import java.util.Stack;
 
 public class AhegaoTransformer extends AbstractTransformer {
+
+    private static final String AHEGAO_FIELD_NAME = "nothing_to_see_here";
+
     public AhegaoTransformer(Skidfuscator skidfuscator) {
         super(skidfuscator, "Ahegao");
     }
@@ -43,9 +46,15 @@ public class AhegaoTransformer extends AbstractTransformer {
             return;
         }
 
+        if (classNode.getFields().stream()
+                .anyMatch(field -> field.getName().equals(AHEGAO_FIELD_NAME))) {
+            this.skip();
+            return;
+        }
+
         final FieldNode mapleNode = new SkidFieldNodeBuilder(skidfuscator, classNode)
                 .access(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC)
-                .name("nothing_to_see_here")
+                .name(AHEGAO_FIELD_NAME)
                 .desc("[Ljava/lang/String;")
                 .signature(null)
                 .value(null)


### PR DESCRIPTION
This pr fixes an issue where Skidfuscator would fail when the input was either already transformed by Skidfuscator or the user manually added a field called "nothing_to_see_here".